### PR TITLE
Add compatibility with previous node versions

### DIFF
--- a/lib/utils/index-imports.js
+++ b/lib/utils/index-imports.js
@@ -16,9 +16,9 @@ import traverse from 'babel-traverse';
  * Get import nodes from a file.
  */
 
-async function getImportNodes(filePath, configs) {
+function getImportNodes(filePath, configs) {
   try {
-    const fileContents = await fs.readFileAsync(filePath, 'utf8');
+    const fileContents = fs.readFileSync(filePath, 'utf8'); // eslint-disable-line no-sync
     const ast = parse(fileContents, {
       plugins: configs.babylonPlugins,
       sourceType: 'module'
@@ -83,7 +83,7 @@ function indexImports(projectRootPath, jsonStringifiedConfigs) {
     directoryFilter: configs.directoryFilters,
     fileFilter: configs.fileFilters,
     root: projectRootPath
-  }, async (error, entries) => {
+  }, (error, entries) => {
     if (error) {
       console.log(error);
     }
@@ -94,7 +94,7 @@ function indexImports(projectRootPath, jsonStringifiedConfigs) {
       return importNodes;
     });
 
-    const importsList = flatten(await Promise.all(allImportNodes));
+    const importsList = flatten(allImportNodes);
     const specifiersMap = createSpecifiersMap(importsList);
 
     fs.writeFileSync(`${projectRootPath}/.import-helper-data`, JSON.stringify(specifiersMap)); // eslint-disable-line no-sync


### PR DESCRIPTION
This PR removes `async` functions. This allows the plugin to work in environments with previous versions of node.