### PR TITLE
Add setting to keep import data in temp directory

### DIFF
--- a/lib/import-helper.js
+++ b/lib/import-helper.js
@@ -7,8 +7,10 @@
 import { BufferedProcess, CompositeDisposable } from 'atom';
 import { addImport as addImportToFileContents } from './utils/add-import';
 import { head } from 'lodash';
+import { tmpdir } from 'os';
 import View from './view';
 import fs from './utils/fs';
+import md5 from 'md5';
 import path from 'path';
 
 /**
@@ -43,6 +45,12 @@ const config = {
     title: 'Files filter',
     type: 'array'
   },
+  placeImportDataInTemp: {
+    default: true,
+    description: 'Leave checked to use OS\'s temporary directory for keeping import data file. Uncheck to use project folder.',
+    title: 'Use temp directory',
+    type: 'boolean'
+  },
   quotesStyle: {
     default: 'single',
     description: 'Style of quotes for generated imports.',
@@ -63,6 +71,7 @@ function activate(state) {
     babylonPlugins: atom.config.get('import-helper.babylonPlugins'),
     directoryFilters: atom.config.get('import-helper.directoryFilters'),
     fileFilters: atom.config.get('import-helper.fileFilters'),
+    placeImportDataInTemp: atom.config.get('import-helper.placeImportDataInTemp'),
     quotesStyle: atom.config.get('import-helper.quotesStyle')
   };
 
@@ -100,23 +109,34 @@ function activate(state) {
   }
 
   const projectRootPath = head(projectPaths);
+  let importDataDirectory = projectRootPath;
+
+  if (this.configValues.placeImportDataInTemp) {
+    const hashedRootPath = md5(`import-helper::${projectRootPath}`);
+
+    importDataDirectory = `${tmpdir()}/${hashedRootPath}`;
+
+    if (!fs.existsSync(importDataDirectory)) { // eslint-disable-line no-sync
+      fs.mkdirSync(importDataDirectory, 0o744); // eslint-disable-line no-sync
+    }
+  }
 
   const process = new BufferedProcess({ // eslint-disable-line no-unused-vars
-    args: [require.resolve('./utils/index-imports.js'), projectRootPath, JSON.stringify(this.configValues)],
+    args: [require.resolve('./utils/index-imports.js'), projectRootPath, importDataDirectory, JSON.stringify(this.configValues)],
     command: require.resolve('babel-cli/bin/babel-node.js'),
-    exit: async () => this.getSpecifiersDataFromFile(projectRootPath),
+    exit: async () => this.getSpecifiersDataFromFile(importDataDirectory),
     stdout: output => console.log('Index Imports Command: ', output)
   });
 
-  this.getSpecifiersDataFromFile(projectRootPath);
+  this.getSpecifiersDataFromFile(importDataDirectory);
 }
 
 /**
  * Get specifiers data from file.
  */
 
-async function getSpecifiersDataFromFile(projectRootPath) {
-  const contents = await fs.readFileAsync(path.resolve(`${projectRootPath}/.import-helper-data`));
+async function getSpecifiersDataFromFile(importDataDirectory) {
+  const contents = await fs.readFileAsync(path.resolve(`${importDataDirectory}/.import-helper-data`));
 
   this.specifiersMap = JSON.parse(contents);
   this.ready = true;

--- a/lib/utils/index-imports.js
+++ b/lib/utils/index-imports.js
@@ -76,7 +76,7 @@ function createSpecifiersMap(importNodes) {
  * Build import index file.
  */
 
-function indexImports(projectRootPath, jsonStringifiedConfigs) {
+function indexImports(projectRootPath, importDataDirectory, jsonStringifiedConfigs) {
   const configs = JSON.parse(jsonStringifiedConfigs);
 
   readdirp({
@@ -97,7 +97,9 @@ function indexImports(projectRootPath, jsonStringifiedConfigs) {
     const importsList = flatten(allImportNodes);
     const specifiersMap = createSpecifiersMap(importsList);
 
-    fs.writeFileSync(`${projectRootPath}/.import-helper-data`, JSON.stringify(specifiersMap)); // eslint-disable-line no-sync
+    console.log('Import data diretory', importDataDirectory);
+
+    fs.writeFileSync(`${importDataDirectory}/.import-helper-data`, JSON.stringify(specifiersMap)); // eslint-disable-line no-sync
   });
 }
 
@@ -106,8 +108,8 @@ function indexImports(projectRootPath, jsonStringifiedConfigs) {
  */
 
 program
-  .arguments('<projectRootPath> <jsonStringifiedConfigs>')
-  .action((projectRootPath, jsonStringifiedConfigs) => {
-    indexImports(projectRootPath, jsonStringifiedConfigs);
+  .arguments('<projectRootPath> <importDataDirectory> <jsonStringifiedConfigs>')
+  .action((projectRootPath, importDataDirectory, jsonStringifiedConfigs) => {
+    indexImports(projectRootPath, importDataDirectory, jsonStringifiedConfigs);
   })
   .parse(process.argv);

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "bluebird": "3.5.1",
     "commander": "2.11.0",
     "lodash": "4.17.4",
+    "md5": "2.2.1",
     "react": "16.0.0",
     "react-dom": "16.0.0",
     "readdirp": "2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -138,7 +138,7 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-cli@^6.26.0:
+babel-cli@6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
   dependencies:
@@ -307,7 +307,7 @@ babel-polyfill@^6.26.0:
     core-js "^2.5.0"
     regenerator-runtime "^0.10.5"
 
-babel-preset-es2017-node7@^0.5.2:
+babel-preset-es2017-node7@0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/babel-preset-es2017-node7/-/babel-preset-es2017-node7-0.5.2.tgz#da6beb760a3f8edb197b06f9ddeefcda9a57e5f2"
   dependencies:
@@ -393,7 +393,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.5.1:
+bluebird@3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
@@ -446,6 +446,10 @@ change-emitter@^0.1.2:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/change-emitter/-/change-emitter-0.1.6.tgz#e8b2fe3d7f1ab7d69a32199aff91ea6931409515"
 
+charenc@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/charenc/-/charenc-0.0.2.tgz#c0a1d2f3a7092e03774bfa83f14c0fc5790a8667"
+
 chokidar@^1.6.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -489,7 +493,7 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^2.11.0:
+commander@2.11.0, commander@^2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
 
@@ -524,6 +528,10 @@ core-js@^2.4.0, core-js@^2.5.0:
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
+
+crypt@~0.0.1:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
 
 cryptiles@2.x.x:
   version "2.0.5"
@@ -699,7 +707,7 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-react@^1.1.7:
+eslint-config-react@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/eslint-config-react/-/eslint-config-react-1.1.7.tgz#a0918d0fc47d0e9bd161a47308021da85d2585b3"
 
@@ -731,7 +739,7 @@ eslint-plugin-mocha@^4.0.0:
   dependencies:
     ramda "^0.24.1"
 
-eslint-plugin-react@^7.4.0:
+eslint-plugin-react@7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.4.0.tgz#300a95861b9729c087d362dd64abcc351a74364a"
   dependencies:
@@ -1171,7 +1179,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.5, is-buffer@~1.1.1:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -1404,7 +1412,7 @@ lodash.pickby@^4.0.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"
 
-lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0:
+lodash@4.17.4, lodash@^4.0.0, lodash@^4.15.0, lodash@^4.17.4, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -1413,6 +1421,14 @@ loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
     js-tokens "^3.0.0"
+
+md5@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/md5/-/md5-2.2.1.tgz#53ab38d5fe3c8891ba465329ea23fac0540126f9"
+  dependencies:
+    charenc "~0.0.1"
+    crypt "~0.0.1"
+    is-buffer "~1.1.1"
 
 micromatch@^2.1.5:
   version "2.3.11"
@@ -1694,7 +1710,7 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom@^16.0.0:
+react-dom@16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
   dependencies:
@@ -1703,7 +1719,7 @@ react-dom@^16.0.0:
     object-assign "^4.1.1"
     prop-types "^15.6.0"
 
-react@^16.0.0:
+react@16.0.0:
   version "16.0.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
   dependencies:
@@ -1747,7 +1763,7 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-recompose@^0.26.0:
+recompose@0.26.0:
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
   dependencies:


### PR DESCRIPTION
This PR adds a setting that if checked allows to use the OS's temporary directory for keeping import data file i.e `.import-helper-data` for each project.

Closes #3.